### PR TITLE
Fix Condition Evaluation for Skipped Predecessors

### DIFF
--- a/pyautocausal/orchestration/nodes.py
+++ b/pyautocausal/orchestration/nodes.py
@@ -229,8 +229,14 @@ class Node(BaseNode):
             raise ValueError(f"Error evaluating condition for node {self.name}: {str(e)}")
 
     def should_execute(self) -> bool:
+        """Check if the node should be executed based on predecessors and condition."""
         try:
-            return self.condition_satisfied() and not self.has_skipped_predecessors()
+            # First check if any predecessors were skipped
+            if self.has_skipped_predecessors():
+                return False
+            
+            # Only evaluate condition if no predecessors were skipped
+            return self.condition_satisfied()
         except Exception as e:
             self.mark_failed()
             raise ValueError(f"Error evaluating condition for node {self.name}: {str(e)}")
@@ -239,10 +245,8 @@ class Node(BaseNode):
         """Template method that handles state management and conditional execution"""
         self.execution_count += 1
         try:
-            # Check condition satisfaction before executing
-            condition_satisfied = self.condition_satisfied()
+            # First check if any predecessors were skipped
             has_skipped_predecessors = self.has_skipped_predecessors()
-            
             if has_skipped_predecessors:
                 self.mark_skipped()
                 self.graph.logger.info(
@@ -250,6 +254,8 @@ class Node(BaseNode):
                 )
                 return
             
+            # Only evaluate condition if no predecessors were skipped
+            condition_satisfied = self.condition_satisfied()
             if not condition_satisfied:
                 self.mark_skipped()
                 if self.condition:

--- a/pyautocausal/orchestration/nodes.py
+++ b/pyautocausal/orchestration/nodes.py
@@ -231,12 +231,8 @@ class Node(BaseNode):
     def should_execute(self) -> bool:
         """Check if the node should be executed based on predecessors and condition."""
         try:
-            # First check if any predecessors were skipped
-            if self.has_skipped_predecessors():
-                return False
-            
-            # Only evaluate condition if no predecessors were skipped
-            return self.condition_satisfied()
+            return not self.has_skipped_predecessors() and self.condition_satisfied()
+
         except Exception as e:
             self.mark_failed()
             raise ValueError(f"Error evaluating condition for node {self.name}: {str(e)}")


### PR DESCRIPTION
**Summary:**
This PR fixes a bug where conditions were evaluated for nodes with skipped predecessors, leading to `AttributeError`. 

**Changes:**
- Updated the `should_execute()` method to check for skipped predecessors before evaluating conditions.
- Added a test case `test_condition_not_evaluated_with_skipped_predecessors()` to ensure conditions are not evaluated when predecessors are skipped.
